### PR TITLE
Nested grid fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,10 +32,10 @@ open-source, and user-driven projects.
 
 For nearly any application you might have in the geosciences, you can start using
 this powerful, free software stack *today* with minimal friction. However,
-one friction point for GEOS-Chem users is that it is difficult to work with legacy
-bpch-format diagnostics files. **xbpch** solves this problem by providing a
-convenient and performant way to read these files into a modern Python-based
-analysis or workflow.
+one friction point that has tripped up adoption by GEOS-Chem users is that it
+is difficult to work with legacy bpch-format diagnostics files. **xbpch**
+solves this problem by providing a convenient and performant way to read
+these files into a modern Python-based analysis or workflow.
 
 Furthermore, **xbpch** is 100% future-proof. In two years, when your GEOS-Chem
 simulations are writing NetCDF diagnostics, you won't need to change more than a
@@ -126,7 +126,7 @@ solving this problem.
 Acknowledgments
 ---------------
 
-This utility packages together a few pre-existing but toolkits which
+This utility packages together a few pre-existing toolkits which
 have been floating around the Python-GEOS-Chem community. In particular,
 I would like to acknowledge the following pieces of software which I have
 built this utility around:

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -57,6 +57,23 @@ fields, this would entail
     )
 
 
+What Works and Doesn't Work
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**xbpch** should work with most standard GEOS-Chem outputs going back to at
+least v9-02. It has been tested against some of these standard outputs, but
+not exhaustively. If you have an idiosyncratic GEOS-Chem output (e.g. from a
+specialized version of the model with custom tracers or a new grid), please
+give **xbpch** a try and if it fails, post a `an Issue on our GitHub page <https://github.com/darothen/xbpch/issues>`_
+to let us know.
+
+The following configurations have been tested and vetted:
+
+- Standard output on standard grids
+- ND49 output on standard grids
+- ND49 output on nested North America grid (should work for all nested grids)
+
+
 Eager vs Lazy Loading
 ^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This is a patch which adds some logic that allows us to infer whether or not a "nested grid" is contained in an output file. We know that's the case if the metadata for each chunk in a BPCH file indicates that it is a coordinate origin different then (1, 1, 1). Since we know the shape of the array and where it's origin is, we can slice out the longitudes/latitudes corresponding to the nested grid from the full, global grid computed for its parent grid resolution.